### PR TITLE
AndroidでmBaaS利用できない不具合対応

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,8 +6,8 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SaveScore.unity
-  - enabled: 1
     path: Assets/Scenes/Stage.unity
+  - enabled: 1
+    path: Assets/Scenes/SaveScore.unity
   - enabled: 1
     path: Assets/Scenes/LeaderBoard.unity

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -103,7 +103,7 @@ PlayerSettings:
   aotOptions: 
   apiCompatibilityLevel: 2
   stripEngineCode: 1
-  iPhoneStrippingLevel: 2
+  iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   iPhoneBuildNumber: 0
   ForceInternetPermission: 0


### PR DESCRIPTION
## 概要(Summary)

以下を対応しました
* Android実機でmBaaSが動作しない問題対応（Stripping Levelの変更）
* 起動画面をスコア入力画面からタイトル画面に変更